### PR TITLE
Log file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 .kconfig
 
 # Auto-generated Kconfig
-Kconfig
+/Kconfig

--- a/telemetry/Kconfig
+++ b/telemetry/Kconfig
@@ -47,7 +47,7 @@ config PYGMY_TELEM_PWRFS
 
 config PYGMY_TELEM_USRFS
     string "User file system path"
-    default "/usrfs"
+    default "/ejectfs"
     ---help---
         The path to the user file system (for log extraction on host computer)
 

--- a/telemetry/helptext.h
+++ b/telemetry/helptext.h
@@ -7,16 +7,17 @@
 "  help        Display this help text.\n    reboot      Reboot the Pygmy.\n  " \
 "  save        Save newly configured settings to the Pygmy's EEPROM (memory)." \
 "\n    current     Print the currently saved settings.\n    modified    Print" \
-" the modified settings.\n\nRADIO CONFIGURATION COMMANDS:\n\n    callsign    " \
-"Set the user call sign for signing packets.\n    frequency   Set the operati" \
-"ng frequency of the radio module in Hz.\n    bandwidth   Set the operating b" \
-"andwidth of the radio module in kHz.\n    preamble    Set the preamble lengt" \
-"h for radio packets, in bytes.\n    spread      Set the spread factor of the" \
-" radio.\n    mod         Set the modulation mode of the radio. Either 'lora'" \
-" or 'fsk'.\n    txpower     Set the radio transmit power in dBm.\n\nIMU CONF" \
-"IGURATION COMMANDS:\n\n    xl_fsr      Set the full scale range of the accel" \
-"erometer, in Gs.\n    gyro_fsr    Set the full scale range of the gyroscope " \
-"in degrees per second.\n    xl_off      Set the calibration offsets of the a" \
-"ccelerometer in m/s^2.\n                Offsets are subtracted from readings" \
-".\n    gyro_off    Set the calibration offsets of the accelerometer in m/s^2" \
-".\n                Offsets are subtracted from readings.\n"
+" the modified settings.\n    copy        Copy all log files to FAT32 partiti" \
+"on for user access.\n\nRADIO CONFIGURATION COMMANDS:\n\n    callsign    Set " \
+"the user call sign for signing packets.\n    frequency   Set the operating f" \
+"requency of the radio module in Hz.\n    bandwidth   Set the operating bandw" \
+"idth of the radio module in kHz.\n    preamble    Set the preamble length fo" \
+"r radio packets, in bytes.\n    spread      Set the spread factor of the rad" \
+"io.\n    mod         Set the modulation mode of the radio. Either 'lora' or " \
+"'fsk'.\n    txpower     Set the radio transmit power in dBm.\n\nIMU CONFIGUR" \
+"ATION COMMANDS:\n\n    xl_fsr      Set the full scale range of the accelerom" \
+"eter, in Gs.\n    gyro_fsr    Set the full scale range of the gyroscope in d" \
+"egrees per second.\n    xl_off      Set the calibration offsets of the accel" \
+"erometer in m/s^2.\n                Offsets are subtracted from readings.\n " \
+"   gyro_off    Set the calibration offsets of the accelerometer in m/s^2.\n " \
+"               Offsets are subtracted from readings.\n"

--- a/telemetry/helptext.txt
+++ b/telemetry/helptext.txt
@@ -13,6 +13,7 @@ BASIC COMMANDS:
     save        Save newly configured settings to the Pygmy's EEPROM (memory).
     current     Print the currently saved settings.
     modified    Print the modified settings.
+    copy        Copy all log files to FAT32 partition for user access.
 
 RADIO CONFIGURATION COMMANDS:
 

--- a/telemetry/log_thread.c
+++ b/telemetry/log_thread.c
@@ -2,6 +2,8 @@
  * Included Files
  ****************************************************************************/
 
+#include <ctype.h>
+#include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <pthread.h>
@@ -13,22 +15,6 @@
 #include "syncro.h"
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#ifndef CONFIG_PYGMY_TELEM_PWRFS
-#define CONFIG_PYGMY_TELEM_PWRFS "/pwrfs"
-#endif
-
-#ifndef CONFIG_PYGMY_TELEM_USRFS
-#define CONFIG_PYGMY_TELEM_USRFS "/usrfs"
-#endif
-
-#ifndef CONFIG_PYGYMY_NLOGSAVE
-#define CONFIG_PYGYMY_NLOGSAVE 20
-#endif
-
-/****************************************************************************
  * Private Data
  ****************************************************************************/
 
@@ -38,7 +24,143 @@ struct packet_s *pkt; /* Shared packet pointer */
  * Private Functions
  ****************************************************************************/
 
+/****************************************************************************
+ * Name: close_fd
+ *
+ * Description:
+ *   Closes the currently open file descriptor as a *`pthread_cleanup`
+ *   routine.
+ ****************************************************************************/
+
 static void close_fd(void *arg) { close(*((int *)(arg))); }
+
+/****************************************************************************
+ * Name: logfile_next
+ *
+ * Description:
+ *   Closes the currently open file descriptor and re-populates it with a new
+ *   one of the next log file. The next log file will have a file-name with
+ *   the next sequence number.
+ *
+ *   NOTE: Does not close file descriptor `fd` if it is a negative number.
+ ****************************************************************************/
+
+static int logfile_next(int *fd, unsigned *seqnum)
+{
+  int err;
+  char filename[sizeof(CONFIG_PYGMY_TELEM_PWRFS "/") + 25];
+
+  /* Close current file if valid */
+
+  if (*fd > 0)
+    {
+      err = close(*fd);
+      if (err < 0)
+        {
+          return errno;
+        }
+    }
+
+  /* Create new file with file name of the next sequence number */
+
+  snprintf(filename, sizeof(filename), CONFIG_PYGMY_TELEM_PWRFS "/log%d.bin",
+           *seqnum);
+
+  /* Create and open this file in write mode */
+
+  err = open(filename, O_WRONLY | O_CREAT);
+  if (err < 0)
+    {
+      return errno;
+    }
+
+  *fd = err;    /* File descriptor was returned */
+  *seqnum += 1; /* Safe to increment sequence number */
+  return 0;
+}
+
+/****************************************************************************
+ * Name: parse_seqnum
+ *
+ * Description:
+ *   Parses a number out of a log filename.
+ ****************************************************************************/
+
+static unsigned parse_seqnum(const char *str)
+{
+  const char *start = str;
+
+  /* Find start digit */
+
+  while (!isdigit(*start))
+    {
+      start++;
+    }
+
+  return strtoul(start, NULL, 10);
+}
+
+/****************************************************************************
+ * Name: logfile_cur_seqnum
+ *
+ * Description:
+ *   Reads through the current log files to find the greatest sequence number.
+ ****************************************************************************/
+
+static int logfile_cur_seqnum(unsigned *seqnum)
+{
+  unsigned maxseq = 0;
+  unsigned seq = 0;
+  struct dirent *de;
+
+  /* Get power safe directory */
+
+  DIR *dir = opendir(CONFIG_PYGMY_TELEM_PWRFS);
+  if (dir == NULL)
+    {
+      return errno;
+    }
+
+  /* Go through all files in the directory and find out their name to parse
+   * out the sequence number.
+   *
+   * NOTE: manpages for `readdir` say to set `errno` to zero prior.
+   */
+
+  errno = 0;
+  while ((de = readdir(dir)) != NULL)
+    {
+      /* Skip non-files just in case */
+
+      if (de->d_type != DT_REG)
+        {
+          continue;
+        }
+
+      /* WARNING: This parsing code makes the assumption that all log file
+       * names have the format "log<n>.bin", and that no other file names will
+       * be present in the power safe directory. */
+
+      seq = parse_seqnum(de->d_name);
+      if (seq > maxseq)
+        {
+          maxseq = seq;
+        }
+    }
+
+  /* `readdir` returned NULL because of error, not because of end of entries
+   */
+
+  if (errno != 0)
+    {
+      closedir(dir);
+      return errno;
+    }
+
+  *seqnum = maxseq + 1; /* Use next highest */
+  closedir(dir);
+  return 0;
+}
 
 /****************************************************************************
  * Public Functions
@@ -49,7 +171,6 @@ static void close_fd(void *arg) { close(*((int *)(arg))); }
  *
  * Description:
  *   Performs logging operations to onboard storage.
- *
  ****************************************************************************/
 
 void *log_thread(void *arg)
@@ -57,14 +178,23 @@ void *log_thread(void *arg)
   syncro_t *syncro = args_syncro(arg);
 
   int err;
-  int pwrfs;
+  int pwrfs = -1;
+  unsigned seqnum = 0;
   ssize_t b_written;
   pkt = NULL;
 
+  /* Get the next available sequence number */
+  err = logfile_cur_seqnum(&seqnum);
+  if (err)
+    {
+      fprintf(stderr, "Couldn't get the next available sequence number.\n");
+      pthread_exit((void *)(long)err);
+    }
+
   /* Open power safe file system */
 
-  pwrfs = open(CONFIG_PYGMY_TELEM_PWRFS "/somefile.bin", O_WRONLY | O_CREAT);
-  if (pwrfs < 0)
+  err = logfile_next(&pwrfs, &seqnum);
+  if (err)
     {
       err = errno;
       fprintf(stderr, "Couldn't open power safe log file: %d\n", err);
@@ -78,7 +208,6 @@ void *log_thread(void *arg)
   unsigned count = 0;
   for (;;)
     {
-
       /* Wait for unlogged packet */
 
       err = syncro_get_unlogged(syncro, &pkt);
@@ -104,8 +233,25 @@ void *log_thread(void *arg)
       if (b_written <= 0)
         {
           err = errno;
-          fprintf(stderr, "Couldn't write data to logfile: %d\n", err);
-          continue;
+
+          /* Some unexpected error */
+
+          if (err != EFBIG)
+            {
+              fprintf(stderr, "Couldn't write data to logfile: %d\n", err);
+              continue;
+            }
+
+          /* File exceeded maximum size, so we need to swap files and
+           * continue. */
+
+          err = logfile_next(&pwrfs, &seqnum);
+          if (err)
+            {
+              fprintf(stderr, "Couldn't create logfile %d: %d\n", seqnum,
+                      err);
+              continue;
+            }
         }
 
       /* Mark packet as logged */
@@ -114,7 +260,7 @@ void *log_thread(void *arg)
 
       /* Sync after `n` packets logged */
 
-      if (count % CONFIG_PYGYMY_NLOGSAVE == 0)
+      if (count % CONFIG_PYGMY_NLOGSAVE == 0)
         {
           err = fsync(pwrfs);
           if (err < 0)


### PR DESCRIPTION
Introduces proper log file numbering, as well as a shell command for copying the files to the user accessible partition. Tested multiple times and works correctly. Unable to test log file swap when files become too large since the littlefs maximum file size is 2GB, which is much larger than I was able to achieve in several minutes of bench testing.